### PR TITLE
fix:Error caught was: No module named 'triton' in windows11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ gradio
 torchmetrics
 encodec
 pytaglib
+gradio==3.35.2
+gradio-client==0.2.7
+pydantic==1.10.9


### PR DESCRIPTION
fix:Error caught was: No module named 'triton' in windows11